### PR TITLE
当前在线用户列表和产品标题栏缩略小图配置

### DIFF
--- a/contact-center/app/src/main/java/com/chatopera/cc/controller/apps/IMController.java
+++ b/contact-center/app/src/main/java/com/chatopera/cc/controller/apps/IMController.java
@@ -569,7 +569,9 @@ public class IMController extends Handler {
             @Valid final String imgurl,
             @Valid final String pid,
             @Valid final String purl,
-            @Valid final boolean isInvite) throws Exception {
+            @Valid final boolean isInvite,
+            @Valid final String osname,
+            @Valid final String browser) throws Exception {
         logger.info(
                 "[index] orgi {}, skill {}, agent {}, traceid {}, isInvite {}, exchange {}", orgi, skill, agent,
                 traceid, isInvite, exchange);
@@ -932,6 +934,8 @@ public class IMController extends Handler {
         }
 
         logger.info("[index] return view");
+        view.addObject("osname", osname);
+        view.addObject("browser", browser);
         return view;
     }
 
@@ -1025,10 +1029,10 @@ public class IMController extends Handler {
                 view.addObject("aiid", invite.getAiid());
             }
         }
-
+        view.addObject("osname", BrowserInfoUtils.parseBrowserHostOSFromUserAgent(request.getHeader("User-Agent")));
+        view.addObject("browser", BrowserInfoUtils.parseBrowserFromUserAgent(request.getHeader("User-Agent")));
         return view;
     }
-
 
     @RequestMapping("/leavemsg/save")
     @Menu(type = "admin", subtype = "user")

--- a/contact-center/app/src/main/java/com/chatopera/cc/controller/apps/IMController.java
+++ b/contact-center/app/src/main/java/com/chatopera/cc/controller/apps/IMController.java
@@ -588,6 +588,7 @@ public class IMController extends Handler {
         }
 
         ModelAndView view = request(super.createRequestPageTempletResponse("/apps/im/index"));
+        view.addObject("systemConfig", MainUtils.getSystemConfig());
         Optional<BlackEntity> blackOpt = cache.findOneBlackEntityByUserIdAndOrgi(userid, Constants.SYSTEM_ORGI);
         CousultInvite invite = OnlineUserProxy.consult(appid, orgi);
         if (StringUtils.isNotBlank(

--- a/contact-center/app/src/main/java/com/chatopera/cc/util/BrowserInfoUtils.java
+++ b/contact-center/app/src/main/java/com/chatopera/cc/util/BrowserInfoUtils.java
@@ -1,0 +1,65 @@
+package com.chatopera.cc.util;
+
+public class BrowserInfoUtils {
+    private BrowserInfoUtils() {
+        throw new UnsupportedOperationException();
+    }
+
+    public static String parseBrowserHostOSFromUserAgent(String userAgentFromRequest) {
+
+        String os = "";
+
+        if (userAgentFromRequest.toLowerCase().indexOf("windows") >= 0) {
+            os = "Windows";
+        } else if (userAgentFromRequest.toLowerCase().indexOf("mac") >= 0) {
+            os = "Mac";
+        } else if (userAgentFromRequest.toLowerCase().indexOf("x11") >= 0) {
+            os = "Unix";
+        } else if (userAgentFromRequest.toLowerCase().indexOf("android") >= 0) {
+            os = "Android";
+        } else if (userAgentFromRequest.toLowerCase().indexOf("iphone") >= 0) {
+            os = "IPhone";
+        } else {
+            os = "UnKnown, User-Agent: " + userAgentFromRequest;
+        }
+        return os;
+    }
+
+    public static String parseBrowserFromUserAgent(String userAgentFromRequest) {
+        String lowerCase = userAgentFromRequest.toLowerCase();
+
+        String browser = "";
+
+        if (lowerCase.contains("edge")) {
+            browser = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Edge")).split(" ")[0]).replace("/", "-");
+        } else if (lowerCase.contains("msie")) {
+            String substring = userAgentFromRequest.substring(userAgentFromRequest.indexOf("MSIE")).split(";")[0];
+            browser = substring.split(" ")[0].replace("MSIE", "IE") + "-" + substring.split(" ")[1];
+        } else if (lowerCase.contains("safari") && lowerCase.contains("version")) {
+            browser = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Safari")).split(" ")[0]).split("/")[0]
+                    + "-" + (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Version")).split(" ")[0]).split("/")[1];
+        } else if (lowerCase.contains("opr") || lowerCase.contains("opera")) {
+            if (lowerCase.contains("opera")) {
+                browser = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Opera")).split(" ")[0]).split("/")[0]
+                        + "-" + (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Version")).split(" ")[0]).split("/")[1];
+            } else if (lowerCase.contains("opr")) {
+                browser = ((userAgentFromRequest.substring(userAgentFromRequest.indexOf("OPR")).split(" ")[0]).replace("/", "-"))
+                        .replace("OPR", "Opera");
+            }
+        } else if (lowerCase.contains("chrome")) {
+            browser = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Chrome")).split(" ")[0]).replace("/", "-");
+        } else if ((lowerCase.indexOf("mozilla/7.0") > -1) || (lowerCase.indexOf("netscape6") != -1) ||
+                (lowerCase.indexOf("mozilla/4.7") != -1) || (lowerCase.indexOf("mozilla/4.78") != -1) ||
+                (lowerCase.indexOf("mozilla/4.08") != -1) || (lowerCase.indexOf("mozilla/3") != -1)) {
+            browser = "Netscape-?";
+        } else if (lowerCase.contains("firefox")) {
+            browser = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("Firefox")).split(" ")[0]).replace("/", "-");
+        } else if (lowerCase.contains("rv")) {
+            String IEVersion = (userAgentFromRequest.substring(userAgentFromRequest.indexOf("rv")).split(" ")[0]).replace("rv:", "-");
+            browser = "IE" + IEVersion.substring(0, IEVersion.length() - 1);
+        } else {
+            browser = "UnKnown, User-Agent: " + userAgentFromRequest;
+        }
+        return browser;
+    }
+}

--- a/contact-center/app/src/main/resources/templates/apps/im/index.html
+++ b/contact-center/app/src/main/resources/templates/apps/im/index.html
@@ -8,8 +8,7 @@
 		content="width=device-width, maximum-scale=1.0, initial-scale=1.0,initial-scale=1.0,user-scalable=no" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
     <title>在线咨询</title>
-    
-	<link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico?t=1489039620156"/>
+	<link rel="shortcut icon" type="image/x-icon" href="<#if systemConfig?? && systemConfig.favlogo?? && systemConfig.favlogo != ''>/res/image.html?id=${systemConfig.favlogo?url}<#else>/images/favicon.ico?t=${.now?long}</#if>"/>
     <link rel="stylesheet" type="text/css" href="/im/css/ukefu.css">
     <link rel="stylesheet" id="skin" type="text/css" href="/im/css/default/ukefu.css">
     <!-- kindeditor -->

--- a/contact-center/app/src/main/resources/templates/apps/im/mobile.html
+++ b/contact-center/app/src/main/resources/templates/apps/im/mobile.html
@@ -7,7 +7,8 @@
 		content="width=device-width, maximum-scale=1.0, initial-scale=1.0,initial-scale=1.0,user-scalable=no" />
 	<meta name="apple-mobile-web-app-capable" content="yes" />
     <title>智能客服</title>
-    
+
+	<link rel="shortcut icon" type="image/x-icon" href="<#if systemConfig?? && systemConfig.favlogo?? && systemConfig.favlogo != ''>/res/image.html?id=${systemConfig.favlogo?url}<#else>/images/favicon.ico?t=${.now?long}</#if>"/>
 	<link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico?t=1489039620156"/>
     <link rel="stylesheet" type="text/css" href="/im/css/ukefu.css">
     <link rel="stylesheet" id="skin" type="text/css" href="/im/css/default/ukefu.css">

--- a/contact-center/app/src/main/resources/templates/apps/im/text.html
+++ b/contact-center/app/src/main/resources/templates/apps/im/text.html
@@ -7,7 +7,7 @@
     var cskefuOnlineUserId;
     var ukefu = {
         time : new Date().getTime(),
-        chat : "/im/index.html?appid=${appid!''}<#if id??>&id=${id}</#if><#if aiid??>&aiid=${aiid}</#if><#if exchange??>&exchange=${exchange}</#if><#if name??>&name=${name}</#if><#if email??>&email=${email}</#if><#if phone??>&phone=${phone}</#if>&orgi=${orgi!''}&client=${client}&type=text<#if skill??>&skill=${skill}</#if><#if agent??>&agent=${agent}</#if>" ,
+        chat : "/im/index.html?appid=${appid!''}<#if id??>&id=${id}</#if><#if aiid??>&aiid=${aiid}</#if><#if exchange??>&exchange=${exchange}</#if><#if name??>&name=${name}</#if><#if email??>&email=${email}</#if><#if phone??>&phone=${phone}</#if>&orgi=${orgi!''}&client=${client}&type=text<#if skill??>&skill=${skill}</#if><#if agent??>&agent=${agent}</#if><#if browser??>&browser=${browser}</#if><#if osname??>&osname=${osname}</#if>" ,
         config : function(d){
             data = d ;
             if(d.id != null && d.id != ''){


### PR DESCRIPTION
<!--- 在标题中简略说明问题 -->

## 描述
<!--- 详细的描述变更 -->

首页-显示当前在线用户列表
系统设置->“产品标题栏缩略小图”配置完后，客户侧标题栏显示新配置的图标

## 解决的问题
<!--- 为什么变更是必要的？ -->
1.有客户在线时，首页的当前在线用户列表，仍然为空
2.在系统设置里配置了“产品标题栏缩略小图”后，新进入的客户，标题栏仍然显示春松客服图标
<!--- 如果这个PR解决了其他Issue，添加链接 -->

## 测试情况
<!--- 详细介绍怎么测试变更了 -->
<!--- 介绍测试环境 -->
java8.0u261 + maven3.6.3 + windows10 + mysql 5.7.23 + idea2020.2 + redis 6 + activemq5.16 + es 2.4.6
<!--- 变更对其他代码的影响 -->

## 截屏

## 变更的类型
<!--- 变更有哪些特点，添加 `x` 到下面的对应项目中: -->
- [ x ] 解决Bug
- [ ] 新功能（不影响其他功能）
- [ ] 对其他功能有影响

## 检查:
<!--- 检查下面，各项，添加 `x` 到下面的对应项目中: -->
- [ ] 我的变更和代码规范一致
- [ ] 我的变更需要更新文档
- [ ] 我已经更新了对应的文档
- [ ] 我增加的代码有单元测试
- [ ] 所有单元测试都能通过
